### PR TITLE
Add Jest tests for commands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,6 +69,14 @@ node cli　[command] [options]
 node cli GetReportFile pdf -r 42337
 ```
 
+### テストの実行
+
+```sh
+npm test
+```
+
+上記コマンドで Jest を用いた単体テストを実行できます。
+
 # 免責事項
 
 本ソフトウェア「i-Repo CLI Copilot」は、i-Reporter API を活用したコミュニティ主導のオープンソースプロジェクトとして提供されています。以下の点にご留意ください：

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +17,9 @@
     "inquirer": "^12.1.0",
     "openai": "^4.70.2",
     "readline": "^1.3.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "axios-mock-adapter": "^1.21.2"
   }
 }

--- a/test/AutoGenerate.test.js
+++ b/test/AutoGenerate.test.js
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import fs from 'fs';
+import { jest } from '@jest/globals';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+jest.unstable_mockModule('../utils/sessionManager.js', () => ({
+  getSession: jest.fn(() => Promise.resolve('sid=123')),
+}));
+
+let autoGenerate;
+
+beforeEach(async () => {
+  process.env.API_BASE_URL = 'https://example.com';
+  const mock = new MockAdapter(axios);
+  mock.onPost('https://example.com/ConMasAPI/Rests/APIExecute.aspx').reply(200, 'ok');
+  jest.spyOn(fs, 'createReadStream').mockReturnValue({});
+  jest.spyOn(axios, 'post');
+  ;({ action: autoGenerate } = await import('../commands/AutoGenerate.js'));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('autoGenerate posts form data', async () => {
+  const tmp = path.join(path.dirname(fileURLToPath(import.meta.url)), 'tmp.txt');
+  fs.writeFileSync(tmp, 'data');
+  await autoGenerate({ type: 'csv', dataFile: tmp, encoding: 'utf8' });
+  expect(axios.post).toHaveBeenCalled();
+  fs.unlinkSync(tmp);
+});

--- a/test/DownloadCsv.test.js
+++ b/test/DownloadCsv.test.js
@@ -1,0 +1,27 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import fs from 'fs';
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../utils/sessionManager.js', () => ({
+  getSession: jest.fn(() => Promise.resolve('sid=123')),
+}));
+
+let downloadCsv;
+
+beforeEach(async () => {
+  process.env.API_BASE_URL = 'https://example.com/api';
+  const mock = new MockAdapter(axios);
+  mock.onPost('').reply(200, 'zipdata');
+  jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+  ;({ action: downloadCsv } = await import('../commands/DownloadCsv.js'));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('downloadCsv posts and saves file', async () => {
+  await downloadCsv({ reportId: '1' });
+  expect(fs.writeFileSync).toHaveBeenCalledWith('report.zip', 'zipdata');
+});

--- a/test/GetReportDetail.test.js
+++ b/test/GetReportDetail.test.js
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../utils/sessionManager.js', () => ({
+  getSession: jest.fn(() => Promise.resolve('sid=123')),
+}));
+
+let getReportDetail;
+
+beforeEach(async () => {
+  process.env.API_BASE_URL = 'https://example.com/api';
+  const mock = new MockAdapter(axios);
+  mock.onPost('').reply(200, '<xml></xml>');
+  ;({ action: getReportDetail } = await import('../commands/GetReportDetail.js'));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('getReportDetail posts and returns data', async () => {
+  const data = await getReportDetail('1');
+  expect(data).toBe('<xml></xml>');
+});

--- a/test/GetReportFile.test.js
+++ b/test/GetReportFile.test.js
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import fs from 'fs';
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../utils/sessionManager.js', () => ({
+  getSession: jest.fn(() => Promise.resolve('sid=123')),
+}));
+
+let getReportFile;
+
+beforeEach(async () => {
+  process.env.API_BASE_URL = 'https://example.com/api';
+  const mock = new MockAdapter(axios);
+  mock.onPost('').reply(200, 'filedata', {
+    'content-disposition': 'attachment; filename="sample.pdf"',
+  });
+  jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+  ;({ action: getReportFile } = await import('../commands/GetReportFile.js'));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('getReportFile posts and saves file', async () => {
+  await getReportFile({ fileType: 'pdf', report: '1' });
+  expect(fs.writeFileSync).toHaveBeenCalledWith('sample.pdf', 'filedata');
+});


### PR DESCRIPTION
## Summary
- add Jest & axios-mock-adapter dev dependencies and test script
- create Jest config
- write unit tests for command actions
- document running tests in README

## Testing
- `npm test` *(fails: jest not found)*